### PR TITLE
Fix mobile menu toggle icon state and dark-mode switch visual bleed

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1376,6 +1376,7 @@ textarea {
 }
 .mode-icon-sun {
     left: 11px;
+    opacity: 0;
 }
 .mode-icon-moon {
     right: 10px;

--- a/css/style.css
+++ b/css/style.css
@@ -1350,17 +1350,19 @@ textarea {
     height: 100%;
     background: #ff5a00;
     border-radius: 999px;
+    overflow: hidden;
     transition: background .25s ease;
     box-shadow: inset 0 2px 4px rgba(0, 0, 0, .25);
 }
 .mode-switch-thumb {
     position: absolute;
     top: 3px;
-    right: 3px;
+    left: 3px;
     width: 22px;
     height: 22px;
     border-radius: 50%;
     background: #f2f2f2;
+    z-index: 2;
     box-shadow: 0 2px 6px rgba(0, 0, 0, .35);
     transition: transform .25s ease;
 }
@@ -1389,7 +1391,7 @@ textarea {
     opacity: 1;
 }
 .mode-switch input:checked ~ .mode-switch-thumb {
-    transform: translateX(-44px);
+    transform: translateX(44px);
 }
 
 

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <link href="css/bootstrap.min.css" rel="stylesheet">
     <link href="css/font-awesome.min.css" rel="stylesheet">
     <link href="css/animate.css" rel="stylesheet">
-    <link href="css/style.css?22.04.26v2" rel="stylesheet">
+    <link href="css/style.css?22.04.26v3" rel="stylesheet">
     <link href="css/style-tool-tip-text.css?09.06.22" rel="stylesheet">
     <link href="css/style-work-exp.css?09.06.22" rel="stylesheet">
     <link href="css/color/default.css?09.06.22" id="theme" rel="stylesheet">
@@ -806,7 +806,7 @@
     <script src="js/jquery-1.12.4.min.js"></script>
     <script src="js/bootstrap.min.js"></script>
     <script src="js/scroll.js"></script>
-    <script src="js/scripts.js?22.04.2026"></script>
+    <script src="js/scripts.js?22.04.26v3"></script>
     <!--  end JS  -->
 </body>
 

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -74,16 +74,24 @@
           $(this).closest("li").addClass("active"));
       }));
   }));
+const syncNavbarToggleState = function () {
+  const isMobileMenuOpen = $("#header-navbar").hasClass("in");
+  $(".navbar-toggle").toggleClass("collapsed", !isMobileMenuOpen);
+};
+
 $(document).on("click", ".nav a", function () {
-  $(".navbar-collapse").removeClass("in");
-  $(".navbar-toggle .fa-bars").css("display", "block");
-  $(".navbar-toggle .fa-close").css("display", "none");
-  $(".navbar-toggle").addClass("collapsed");
+  $("#header-navbar").collapse("hide");
 });
-$(document).on("click", ".navbar-toggle.collapsed", function () {
-  $(".navbar-toggle .fa-bars").css("display", "none");
-  $(".navbar-toggle .fa-close").css("display", "block");
+
+$("#header-navbar").on("shown.bs.collapse hidden.bs.collapse", function () {
+  syncNavbarToggleState();
 });
+
+$(window).on("resize", function () {
+  syncNavbarToggleState();
+});
+
+syncNavbarToggleState();
 $(document).on("click", ".filter-button", function () {
   var value = $(this).attr("data-filter");
 


### PR DESCRIPTION
### Motivation
- Prevent the dark-mode switch thumb from revealing the sun icon (visual bleed) when toggled. 
- Ensure the mobile menu button reliably returns to the hamburger state after closing, navigation clicks and window resizes to avoid the X icon getting stuck.

### Description
- Updated `css/style.css` to add `overflow: hidden` to `.mode-switch-track`, move `.mode-switch-thumb` from `right` to `left`, add `z-index`, and flip the checked translation to `transform: translateX(44px)` so the thumb moves correctly and the track clips content.
- Replaced brittle manual DOM `display` toggles in `js/scripts.js` with a `syncNavbarToggleState` helper that synchronizes the `.navbar-toggle` `collapsed` state from the real collapse state of `#header-navbar`, and wired it to `shown.bs.collapse` / `hidden.bs.collapse`, `resize`, and initial run.
- Changed nav link click behavior to call `$('#header-navbar').collapse('hide')` so the collapse lifecycle drives the toggle state instead of ad-hoc style changes.

### Testing
- Ran `node --check js/scripts.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b87d538883339fb1a744822ea44a)